### PR TITLE
Specify "main" file for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,12 @@
+{
+  "name": "requirejs-domready",
+  "version": "2.0.1",
+  "main": "domReady.js",
+  "dependencies": {
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ]
+}


### PR DESCRIPTION
This repo has already been registered to bower. Using the name requirejs-domready I've added this file using that name and the current version number.
The key point is that I've specified a "main" file. Allowing easier integration, and allows me to use other tools like this https://github.com/yeoman/grunt-bower-requirejs
