### PR TITLE
re-adds use of readyState 'interactive'

### DIFF
--- a/domReady.js
+++ b/domReady.js
@@ -83,12 +83,14 @@ define(function () {
         //entering "interactive" or "complete". More details:
         //http://dev.w3.org/html5/spec/the-end.html#the-end
         //http://stackoverflow.com/questions/3665561/document-readystate-of-interactive-vs-ondomcontentloaded
-        //Hmm, this is more complicated on further use, see "firing too early"
-        //bug: https://github.com/requirejs/domReady/issues/1
-        //so removing the || document.readyState === "interactive" test.
-        //There is still a window.onload binding that should get fired if
-        //DOMContentLoaded is missed.
-        if (document.readyState === "complete") {
+        //Added browser sniff when available to skip load handler for IE9 if
+        //readyState is 'interactive'.
+        if(document.readyState === "interactive") {
+            if(!window.navigator.userAgent || window.navigator.userAgent.indexOf('MSIE 9') === -1) {
+                pageLoaded();
+            }
+        }
+        else if(document.readyState === "complete") {
             pageLoaded();
         }
     }


### PR DESCRIPTION
Re-adds use of readyState 'interactive' on initial status check for faster response if DOMContentLoaded has already fired on script init. A browser sniff excludes IE 9 from this behavior due to issue #1 (https://github.com/requirejs/domReady/issues/1).
