### PR TITLE
Trigger page load listeners when complete or no longer loading

### DIFF
--- a/domReady.js
+++ b/domReady.js
@@ -83,7 +83,8 @@ define(function () {
         // Older IE sometimes signals "interactive" too soon
         if (document.readyState === "complete" || 
             (document.readyState !== "loading" && !document.documentElement.doScroll)) {
-            pageLoaded();
+            // Handle it asynchronously to allow scripts the opportunity to delay ready
+            setTimeout(pageLoaded);
         }
     }
 

--- a/domReady.js
+++ b/domReady.js
@@ -77,18 +77,12 @@ define(function () {
             }
         }
 
-        //Check if document already complete, and if so, just trigger page load
-        //listeners. Latest webkit browsers also use "interactive", and
-        //will fire the onDOMContentLoaded before "interactive" but not after
-        //entering "interactive" or "complete". More details:
-        //http://dev.w3.org/html5/spec/the-end.html#the-end
-        //http://stackoverflow.com/questions/3665561/document-readystate-of-interactive-vs-ondomcontentloaded
-        //Hmm, this is more complicated on further use, see "firing too early"
-        //bug: https://github.com/requirejs/domReady/issues/1
-        //so removing the || document.readyState === "interactive" test.
-        //There is still a window.onload binding that should get fired if
-        //DOMContentLoaded is missed.
-        if (document.readyState === "complete") {
+        // Catch cases where $(document).ready() is called
+        // after the browser event has already occurred.
+        // Support: IE6-10
+        // Older IE sometimes signals "interactive" too soon
+        if (document.readyState === "complete" || 
+            (document.readyState !== "loading" && !document.documentElement.doScroll)) {
             pageLoaded();
         }
     }


### PR DESCRIPTION
RequireJS domReady is used in Magento 2, and it was causing following issue https://github.com/magento/magento2/issues/22909, so in Magento there was added local fix on top of this library https://github.com/magento/magento2/pull/23313.

I'd like to submit a fix for this issue to the library itself in order to have ability just update it to latest version and resolve the issue for everyone.

After checking alternatives I found that jQuery has compatible with older IE versions solution, so I think it's better to apply it.

This is port from jQuery https://github.com/jquery/jquery/commit/8c293e62bb39cdf347bd045a1e89a54549f972eb that supports old IE versions.

Fixes #18.
Related to #1